### PR TITLE
Automate FFmpeg XCFramework builds and distribution

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -1,0 +1,99 @@
+name: Build FFmpeg XCFrameworks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build slices (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-13
+            arch: x86_64
+          - runner: macos-14
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build FFmpeg libraries
+        run: |
+          swift package plugin build-ffmpeg --force --arch ${{ matrix.arch }}
+
+      - name: Package build outputs
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/${{ matrix.arch }}
+          rsync -a output/ artifacts/${{ matrix.arch }}/output/
+          ARTIFACT_SUFFIX="-${{ matrix.arch }}" ./Scripts/package_xcframeworks.sh artifacts/${{ matrix.arch }}/packages
+
+      - name: Upload slice artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-${{ matrix.arch }}
+          path: artifacts/${{ matrix.arch }}
+
+  bundle:
+    name: Assemble universal xcframeworks
+    needs: build
+    runs-on: macos-13
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download slice artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ffmpeg-*
+          path: slices
+          merge-multiple: false
+
+      - name: Merge XCFramework slices
+        run: |
+          set -euo pipefail
+          LIBS="libavcodec libavdevice libavfilter libavformat libavutil libpostproc libswresample libswscale"
+          mkdir -p universal/xcframework
+          for LIB in $LIBS; do
+            ARM_DIR="slices/ffmpeg-arm64/output/xcframework/${LIB}.xcframework"
+            X86_DIR="slices/ffmpeg-x86_64/output/xcframework/${LIB}.xcframework"
+            if [ ! -d "$ARM_DIR" ]; then
+              echo "Missing arm64 slice for $LIB" >&2
+              exit 1
+            fi
+            if [ ! -d "$X86_DIR" ]; then
+              echo "Missing x86_64 slice for $LIB" >&2
+              exit 1
+            fi
+
+            DEST="universal/xcframework/${LIB}.xcframework"
+            rm -rf "$DEST"
+            mkdir -p "$DEST"
+            rsync -a "$ARM_DIR/" "$DEST/"
+            rsync -a "$X86_DIR/macos-x86_64" "$DEST/"
+            Scripts/update_xcframework_info.sh "$DEST" "$LIB"
+          done
+
+          ARTIFACT_SUFFIX="" ./Scripts/package_xcframeworks.sh universal/artifacts
+
+      - name: Upload universal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-universal
+          path: universal/artifacts
+
+      - name: Publish release assets
+        if: github.event_name == 'release' && github.event.action == 'published'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG=${{ github.event.release.tag_name }}
+          for FILE in universal/artifacts/*.zip universal/artifacts/*.zip.checksum; do
+            gh release upload "$TAG" "$FILE" --clobber
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,8 @@ jobs:
     - name: Show Swift version
       run: swift --version
 
-    - name: Install FFmpeg
-      run: brew install ffmpeg
-      # Note: We use Homebrew FFmpeg in CI for speed
-      # For custom builds, use: swift package plugin build-ffmpeg
+    - name: Build FFmpeg XCFrameworks
+      run: swift package plugin build-ffmpeg --force
 
     - name: Build
       run: swift build

--- a/README.md
+++ b/README.md
@@ -10,11 +10,9 @@ A Swift wrapper for the FFmpeg API.
 
 ### Prerequisites
 
-You need to install [FFmpeg](http://ffmpeg.org/) (Requires FFmpeg 8.0 or higher) before using this library. On macOS:
-
-```bash
-brew install ffmpeg
-```
+- macOS with Xcode 15 or newer
+- Command Line Tools (`xcode-select --install`)
+- Approximately 15 GB of free disk space when compiling FFmpeg locally
 
 ### Swift Package Manager
 
@@ -40,34 +38,41 @@ The package requires pre-built XCFrameworks. You have two options:
 swift package plugin build-ffmpeg
 ```
 
-This will:
-- Clone FFmpeg 7.1 from the official git repository
-- Compile for your architecture (arm64 or x86_64)
-- Build XCFrameworks with proper structure
-- Place frameworks in `xcframework/` directory
-- Automatically make them available to the package
+The plugin orchestrates `Scripts/build.sh` to:
 
-**Note:** Building takes 10-30 minutes depending on your machine.
+- Download the official FFmpeg `ffmpeg-7.1.tar.xz` source archive from [ffmpeg.org](https://www.ffmpeg.org/download.html#get-sources)
+- Compile every required library slice for your host architecture (either `arm64` or `x86_64`)
+- Produce XCFramework slices for `libavcodec`, `libavdevice`, `libavfilter`, `libavformat`, `libavutil`, `libpostproc`, `libswresample`, and `libswscale`
+- Copy the resulting frameworks into the repository’s `xcframework/` directory so SwiftPM can resolve the binary targets
+
+Use `--force` to rebuild from scratch or pass `--arch` explicitly when driving the plugin from automation:
+
+```bash
+swift package plugin build-ffmpeg --force --arch arm64
+```
+
+> Building FFmpeg locally typically takes 15–30 minutes on GitHub Actions hardware and less on Apple Silicon desktops. The script caches the downloaded source archive to avoid repeated network fetches.
 
 #### Option 2: Manual Build
 
-Run the build script directly:
+Run the build script directly when you prefer not to invoke the plugin (for example, inside CI containers):
 
 ```bash
 ./Scripts/build.sh
 ```
 
-The build process:
-1. Clones FFmpeg from `https://git.ffmpeg.org/ffmpeg.git` (release/7.1 branch)
-2. Configures and compiles FFmpeg with GPL support
-3. Creates framework structures for all FFmpeg libraries (libavcodec, libavdevice, libavfilter, libavformat, libavutil, libpostproc, libswresample, libswscale)
-4. Builds architecture-specific XCFrameworks in `output/xcframework/`
+Key behaviours of the script:
 
-After building, copy the frameworks:
+1. Downloads the FFmpeg 7.1 release tarball from `https://ffmpeg.org/releases/`
+2. Configures and compiles FFmpeg for each architecture requested via the `ARCHS` environment variable (defaults to the host architecture)
+3. Builds framework bundles for all FFmpeg libraries in `output/<arch>/framework`
+4. Emits XCFramework slices under `output/xcframework/`
+
+Copy the generated slices into the repository root if you want SwiftPM to consume them immediately:
 
 ```bash
 mkdir -p xcframework
-cp -R output/xcframework/* xcframework/
+rsync -a output/xcframework/ xcframework/
 ```
 
 ### Packaging for Distribution (Advanced)
@@ -78,7 +83,24 @@ To create distributable zip files with checksums for remote hosting:
 ./Scripts/package_xcframeworks.sh
 ```
 
-This creates zip files and checksums for each XCFramework, which can be uploaded to GitHub Releases or other hosting and referenced via URL in `Package.swift` using `.binaryTarget` with remote URLs.
+Set `ARTIFACT_SUFFIX` to distinguish per-architecture slices when archiving automation output:
+
+```bash
+ARTIFACT_SUFFIX="-arm64" ./Scripts/package_xcframeworks.sh build-artifacts
+```
+
+The script emits zipped XCFrameworks alongside SwiftPM checksums. Upload the zipped bundles to your preferred distribution channel and wire them into `Package.swift` using `.binaryTarget(url:checksum:)` once they are published.
+
+### Continuous Integration and Releases
+
+The repository includes a `Build FFmpeg XCFrameworks` GitHub Actions workflow that runs on pushes, pull requests, manual dispatches, and published releases. The workflow:
+
+1. Builds FFmpeg slices on `macos-13` (Intel) and `macos-14` (Apple Silicon) runners via the package plugin
+2. Packages architecture-specific artifacts and publishes them as workflow artifacts
+3. Merges the slices into universal XCFrameworks with refreshed metadata
+4. Uploads the universal zips and checksums for later consumption and automatically attaches them to GitHub Releases when triggered by a published release
+
+These artifacts serve as the canonical source-of-truth binaries that downstream consumers can reference without rebuilding FFmpeg locally.
 
 ## Documentation
 

--- a/Scripts/build_framework.sh
+++ b/Scripts/build_framework.sh
@@ -1,102 +1,70 @@
 #!/bin/bash
 
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <install-prefix> <library-name> <version> <arch> [output-root]"
+  exit 1
+fi
+
 PREFIX=$1
 LIB_NAME=$2
 LIB_VERSION=$3
+ARCH_NAME=$4
+OUTPUT_ROOT=${5:-$(dirname "$PREFIX")}
 
-# Detect architecture
-ARCH=$(uname -m)
-if [ "$ARCH" = "arm64" ]; then
-    PLATFORM_ID="macos-arm64"
-    ARCH_NAME="arm64"
-elif [ "$ARCH" = "x86_64" ]; then
-    PLATFORM_ID="macos-x86_64"
-    ARCH_NAME="x86_64"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PLATFORM_ID="macos-$ARCH_NAME"
+
+LIB_FRAMEWORK_ROOT="$OUTPUT_ROOT/$ARCH_NAME/framework/$LIB_NAME.framework"
+LIB_XCFRAMEWORK="$OUTPUT_ROOT/xcframework/$LIB_NAME.xcframework"
+
+echo "Preparing framework for $LIB_NAME ($ARCH_NAME)"
+
+rm -rf "$LIB_FRAMEWORK_ROOT"
+mkdir -p "$LIB_FRAMEWORK_ROOT/Headers"
+
+if [ ! -d "$PREFIX/include/$LIB_NAME" ]; then
+  echo "Error: Header directory $PREFIX/include/$LIB_NAME not found"
+  exit 1
 fi
 
-LIB_FRAMEWORK=$PREFIX/framework/$LIB_NAME.framework
-LIB_XCFRAMEWORK=$PREFIX/xcframework/$LIB_NAME.xcframework
-XCFRAMEWORK_DIR=$(dirname $LIB_XCFRAMEWORK)
+rsync -a "$PREFIX/include/$LIB_NAME/" "$LIB_FRAMEWORK_ROOT/Headers/"
+cp "$PREFIX/lib/$LIB_NAME.a" "$LIB_FRAMEWORK_ROOT/$LIB_NAME"
 
-# build framework
-rm -rf $LIB_FRAMEWORK
-
-mkdir -p $LIB_FRAMEWORK/Headers
-cp -R $PREFIX/include/$LIB_NAME/ $LIB_FRAMEWORK/Headers
-
-cp $PREFIX/lib/$LIB_NAME.a $LIB_FRAMEWORK/$LIB_NAME
-
-cat > $LIB_FRAMEWORK/Info.plist << EOF
+cat > "$LIB_FRAMEWORK_ROOT/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$LIB_NAME</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.ffmpeg.$LIB_NAME</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$LIB_NAME</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$LIB_VERSION</string>
-	<key>CFBundleVersion</key>
-	<string>$LIB_VERSION</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleExecutable</key>
+        <string>$LIB_NAME</string>
+        <key>CFBundleIdentifier</key>
+        <string>org.ffmpeg.$LIB_NAME</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>$LIB_NAME</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>$LIB_VERSION</string>
+        <key>CFBundleVersion</key>
+        <string>$LIB_VERSION</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
 </dict>
 </plist>
 EOF
 
-# build xcframework
-rm -rf $LIB_XCFRAMEWORK
+mkdir -p "$LIB_XCFRAMEWORK/$PLATFORM_ID"
+rsync -a "$LIB_FRAMEWORK_ROOT/" "$LIB_XCFRAMEWORK/$PLATFORM_ID/$LIB_NAME.framework/"
 
-# xcodebuild \
-#   -create-xcframework \
-#   -framework $LIB_FRAMEWORK \
-#   -output $LIB_XCFRAMEWORK
-#
-# error: unable to find any specific architecture information in the binary at xxx
+"$SCRIPT_DIR/update_xcframework_info.sh" "$LIB_XCFRAMEWORK" "$LIB_NAME"
 
-mkdir -p $LIB_XCFRAMEWORK/$PLATFORM_ID
-cp -R $LIB_FRAMEWORK $LIB_XCFRAMEWORK/$PLATFORM_ID
-
-cat > $LIB_XCFRAMEWORK/Info.plist << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>AvailableLibraries</key>
-	<array>
-		<dict>
-			<key>LibraryIdentifier</key>
-			<string>$PLATFORM_ID</string>
-			<key>LibraryPath</key>
-			<string>$LIB_NAME.framework</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>$ARCH_NAME</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>macos</string>
-		</dict>
-	</array>
-	<key>CFBundlePackageType</key>
-	<string>XFWK</string>
-	<key>XCFrameworkFormatVersion</key>
-	<string>1.0</string>
-</dict>
-</plist>
-EOF
-
-echo "Built $LIB_NAME.xcframework successfully"
+echo "Built $LIB_NAME.xcframework slice for $ARCH_NAME"

--- a/Scripts/update_xcframework_info.sh
+++ b/Scripts/update_xcframework_info.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <xcframework-dir> <library-name>"
+  exit 1
+fi
+
+XCFRAMEWORK_DIR=$1
+LIB_NAME=$2
+
+if [ ! -d "$XCFRAMEWORK_DIR" ]; then
+  echo "Error: $XCFRAMEWORK_DIR is not a directory"
+  exit 1
+fi
+
+AVAILABLE_LIBRARIES=""
+while IFS= read -r variant_dir; do
+  base=$(basename "$variant_dir")
+  arch_segment=${base#macos-}
+  if [ "$arch_segment" = "$base" ]; then
+    continue
+  fi
+
+  ARCH_ELEMENTS=""
+  for arch in $arch_segment; do
+    ARCH_ELEMENTS+="                        <string>$arch</string>"$'\n'
+  done
+
+  AVAILABLE_LIBRARIES+="                <dict>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>LibraryIdentifier</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>$base</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>LibraryPath</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>$LIB_NAME.framework</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>SupportedArchitectures</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <array>"$'\n'
+  AVAILABLE_LIBRARIES+="$ARCH_ELEMENTS"
+  AVAILABLE_LIBRARIES+="                        </array>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>SupportedPlatform</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>macos</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                </dict>"$'\n'
+
+done < <(find "$XCFRAMEWORK_DIR" -mindepth 1 -maxdepth 1 -type d -not -name "__MACOSX" | sort)
+
+cat > "$XCFRAMEWORK_DIR/Info.plist" <<EOF_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>AvailableLibraries</key>
+        <array>
+$(printf "%b" "$AVAILABLE_LIBRARIES")        </array>
+        <key>CFBundlePackageType</key>
+        <string>XFWK</string>
+        <key>XCFrameworkFormatVersion</key>
+        <string>1.0</string>
+</dict>
+</plist>
+EOF_PLIST

--- a/XCFRAMEWORK_SETUP.md
+++ b/XCFRAMEWORK_SETUP.md
@@ -45,6 +45,7 @@ SwiftFFmpeg Package
    ```bash
    swift package plugin build-ffmpeg
    ```
+   The plugin downloads the official FFmpeg 7.1 release archive, compiles the required libraries for your host architecture, and copies the resulting slices to `xcframework/`.
 3. The frameworks will be placed in `xcframework/` directory
 4. Build your project:
    ```bash
@@ -63,6 +64,12 @@ To force a rebuild:
 swift package plugin build-ffmpeg --force
 ```
 
+Specify a target architecture explicitly when coordinating automation (for example, GitHub Actions matrix builds):
+
+```bash
+swift package plugin build-ffmpeg --force --arch arm64
+```
+
 ## Distribution Setup (Advanced)
 
 For distributing your package to others without requiring them to build FFmpeg:
@@ -78,38 +85,25 @@ xcframework/
 
 ### Option 2: Use Remote Binary Targets (Recommended)
 
-1. Build XCFrameworks locally
+1. Build XCFrameworks locally or download them from the GitHub Actions `ffmpeg-universal` artifact
 2. Package them with checksums:
    ```bash
    ./Scripts/package_xcframeworks.sh
    ```
-3. Upload the generated `.zip` files to GitHub Releases
+   Set `ARTIFACT_SUFFIX` (for example, `-arm64`) when packaging single-architecture slices during CI runs.
+3. Upload the generated `.zip` files to GitHub Releases or another binary registry. The `Build FFmpeg XCFrameworks` workflow will do this automatically when a GitHub Release is published.
 4. Update `Package.swift` to use remote URLs:
    ```swift
    .binaryTarget(
      name: "libavcodec",
-     url: "https://github.com/YOUR_USERNAME/SwiftFFMpeg/releases/download/v1.0.0/libavcodec.xcframework.zip",
+     url: "https://github.com/YOUR_ORG/SwiftFFMpeg/releases/download/v1.0.0/libavcodec.xcframework.zip",
      checksum: "CHECKSUM_FROM_SCRIPT"
    ),
    ```
 
 ## Architecture Support
 
-Currently, the build scripts create **single-architecture** XCFrameworks:
-- **arm64** (Apple Silicon Macs)
-- **x86_64** (Intel Macs)
-
-The XCFramework is built for your current architecture automatically.
-
-### Building Universal XCFrameworks
-
-To create XCFrameworks supporting both architectures:
-
-1. Build on arm64 Mac → creates `macos-arm64` slice
-2. Build on x86_64 Mac → creates `macos-x86_64` slice
-3. Combine using `xcodebuild -create-xcframework` with both slices
-
-This requires access to both architectures or cross-compilation setup.
+The build scripts emit **single-architecture** slices (`macos-arm64` and `macos-x86_64`). The CI workflow automatically merges both slices into universal XCFrameworks and regenerates `Info.plist` metadata using `Scripts/update_xcframework_info.sh`. When running manually you can combine slices by copying the per-architecture directories into a single `.xcframework` directory and re-running the script to refresh the manifest.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- download the official ffmpeg release tarball when building and generate xcframework slices for each architecture
- extend the build plugin and packaging scripts to handle architecture arguments, regenerate Info.plist metadata, and emit reusable artifacts
- document the new automation flow and add GitHub Actions jobs that build, merge, and publish ffmpeg xcframeworks for arm64 and x86_64

## Testing
- swift package describe

------
https://chatgpt.com/codex/tasks/task_e_68e43bd0fe188321a39cb313530c8a19