### PR TITLE
Ensure xcframework artifacts can be tracked

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ framework/
 output/
 FFmpeg-*/
 .DS_Store
+
+# Allow XCFramework artifacts to be tracked
+!xcframework/


### PR DESCRIPTION
## Summary
- update `.gitignore` to explicitly allow committing the `xcframework/` directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e44e3144708321a9d6c31f47edf4de