### PR TITLE
Harden FFmpeg source downloads

### DIFF
--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -23,6 +23,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Checkout FFmpeg sources
+        uses: actions/checkout@v4
+        with:
+          repository: FFmpeg/FFmpeg
+          ref: n8.0
+          path: ffmpeg-src
+          fetch-depth: 1
+
       - name: Select Xcode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
@@ -43,6 +51,7 @@ jobs:
       - name: Build FFmpeg libraries
         env:
           SWIFT_FFMPEG_SKIP_BINARIES: "1"
+          FFMPEG_SOURCE_DIR: ${{ github.workspace }}/ffmpeg-src
         run: |
           swift package plugin build-ffmpeg --force --arch ${{ matrix.arch }}
 

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -1,0 +1,135 @@
+name: Build FFmpeg XCFrameworks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    name: Build slices (${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-15
+            arch: x86_64
+          - runner: macos-15
+            arch: arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
+
+      - name: Verify Swift 6 toolchain
+        run: |
+          set -euo pipefail
+          SWIFT_OUTPUT="$(swift --version)"
+          echo "$SWIFT_OUTPUT"
+          SWIFT_VERSION="$(printf '%s\n' "$SWIFT_OUTPUT" | grep -m1 'Apple Swift version' | awk '{print $4}' || true)"
+          SWIFT_MAJOR="${SWIFT_VERSION%%.*}"
+          if [ -z "$SWIFT_MAJOR" ] || [ "$SWIFT_MAJOR" -lt 6 ]; then
+            echo "Swift 6 or newer is required to precompile FFmpeg. Detected version: ${SWIFT_VERSION:-unknown}" >&2
+            exit 1
+          fi
+
+      - name: Build FFmpeg libraries
+        env:
+          SWIFT_FFMPEG_SKIP_BINARIES: "1"
+        run: |
+          swift package plugin build-ffmpeg --force --arch ${{ matrix.arch }}
+
+      - name: Package build outputs
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/${{ matrix.arch }}
+          rsync -a output/ artifacts/${{ matrix.arch }}/output/
+          ARTIFACT_SUFFIX="-${{ matrix.arch }}" ./Scripts/package_xcframeworks.sh artifacts/${{ matrix.arch }}/packages
+
+      - name: Upload slice artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-${{ matrix.arch }}
+          path: artifacts/${{ matrix.arch }}
+
+  bundle:
+    name: Assemble universal xcframeworks
+    needs: build
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Select Xcode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "16.2"
+
+      - name: Verify Swift 6 toolchain
+        run: |
+          set -euo pipefail
+          SWIFT_OUTPUT="$(swift --version)"
+          echo "$SWIFT_OUTPUT"
+          SWIFT_VERSION="$(printf '%s\n' "$SWIFT_OUTPUT" | grep -m1 'Apple Swift version' | awk '{print $4}' || true)"
+          SWIFT_MAJOR="${SWIFT_VERSION%%.*}"
+          if [ -z "$SWIFT_MAJOR" ] || [ "$SWIFT_MAJOR" -lt 6 ]; then
+            echo "Swift 6 or newer is required to assemble universal FFmpeg artifacts. Detected version: ${SWIFT_VERSION:-unknown}" >&2
+            exit 1
+          fi
+
+      - name: Download slice artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: ffmpeg-*
+          path: slices
+          merge-multiple: false
+
+      - name: Merge XCFramework slices
+        run: |
+          set -euo pipefail
+          LIBS="libavcodec libavdevice libavfilter libavformat libavutil libpostproc libswresample libswscale"
+          mkdir -p universal/xcframework
+          for LIB in $LIBS; do
+            ARM_DIR="slices/ffmpeg-arm64/output/xcframework/${LIB}.xcframework"
+            X86_DIR="slices/ffmpeg-x86_64/output/xcframework/${LIB}.xcframework"
+            if [ ! -d "$ARM_DIR" ]; then
+              echo "Missing arm64 slice for $LIB" >&2
+              exit 1
+            fi
+            if [ ! -d "$X86_DIR" ]; then
+              echo "Missing x86_64 slice for $LIB" >&2
+              exit 1
+            fi
+
+            DEST="universal/xcframework/${LIB}.xcframework"
+            rm -rf "$DEST"
+            mkdir -p "$DEST"
+            rsync -a "$ARM_DIR/" "$DEST/"
+            rsync -a "$X86_DIR/macos-x86_64" "$DEST/"
+            Scripts/update_xcframework_info.sh "$DEST" "$LIB"
+          done
+
+          ARTIFACT_SUFFIX="" ./Scripts/package_xcframeworks.sh universal/artifacts
+
+      - name: Upload universal artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ffmpeg-universal
+          path: universal/artifacts
+
+      - name: Publish release assets
+        if: github.event_name == 'release' && github.event.action == 'published'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG=${{ github.event.release.tag_name }}
+          for FILE in universal/artifacts/*.zip universal/artifacts/*.zip.checksum; do
+            gh release upload "$TAG" "$FILE" --clobber
+          done

--- a/.github/workflows/build-ffmpeg.yml
+++ b/.github/workflows/build-ffmpeg.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-15
+          - runner: macos-13
             arch: x86_64
           - runner: macos-15
             arch: arm64
@@ -46,6 +46,14 @@ jobs:
           if [ -z "$SWIFT_MAJOR" ] || [ "$SWIFT_MAJOR" -lt 6 ]; then
             echo "Swift 6 or newer is required to precompile FFmpeg. Detected version: ${SWIFT_VERSION:-unknown}" >&2
             exit 1
+          fi
+
+      - name: Ensure nasm for x86_64 builds
+        if: matrix.arch == 'x86_64'
+        run: |
+          set -euo pipefail
+          if ! command -v nasm >/dev/null 2>&1; then
+            brew install nasm
           fi
 
       - name: Build FFmpeg libraries

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,14 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Checkout FFmpeg sources
+      uses: actions/checkout@v4
+      with:
+        repository: FFmpeg/FFmpeg
+        ref: n8.0
+        path: ffmpeg-src
+        fetch-depth: 1
+
     - name: Select Xcode version
       uses: maxim-lobanov/setup-xcode@v1
       with:
@@ -35,6 +43,7 @@ jobs:
     - name: Build FFmpeg XCFrameworks
       env:
         SWIFT_FFMPEG_SKIP_BINARIES: "1"
+        FFMPEG_SOURCE_DIR: ${{ github.workspace }}/ffmpeg-src
       run: swift package plugin build-ffmpeg --force
 
     - name: Build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,26 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Select Xcode version
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app/Contents/Developer
+      uses: maxim-lobanov/setup-xcode@v1
+      with:
+        xcode-version: "16.2"
 
-    - name: Show Swift version
-      run: swift --version
+    - name: Verify Swift 6 toolchain
+      run: |
+        set -euo pipefail
+        SWIFT_OUTPUT="$(swift --version)"
+        echo "$SWIFT_OUTPUT"
+        SWIFT_VERSION="$(printf '%s\n' "$SWIFT_OUTPUT" | grep -m1 'Apple Swift version' | awk '{print $4}' || true)"
+        SWIFT_MAJOR="${SWIFT_VERSION%%.*}"
+        if [ -z "$SWIFT_MAJOR" ] || [ "$SWIFT_MAJOR" -lt 6 ]; then
+          echo "Swift 6 or newer is required before building FFmpeg. Detected version: ${SWIFT_VERSION:-unknown}" >&2
+          exit 1
+        fi
 
-    - name: Install FFmpeg
-      run: brew install ffmpeg
-      # Note: We use Homebrew FFmpeg in CI for speed
-      # For custom builds, use: swift package plugin build-ffmpeg
+    - name: Build FFmpeg XCFrameworks
+      env:
+        SWIFT_FFMPEG_SKIP_BINARIES: "1"
+      run: swift package plugin build-ffmpeg --force
 
     - name: Build
       run: swift build

--- a/MIGRATION_SUMMARY.md
+++ b/MIGRATION_SUMMARY.md
@@ -19,10 +19,12 @@ This project has been updated from using **systemLibrary** targets (requiring Ho
   - libswscale.xcframework
 - **Modified**: `CFFmpeg` target now depends on binary targets instead of system libraries
 - **Added**: Platform specification `platforms: [.macOS(.v10_15)]`
+- **Updated**: `swift-tools-version` raised to `6.0`
 
 ### 2. Build Scripts
 - **Modified**: `Scripts/build_framework.sh` - removed individual zip creation
 - **Added**: `Scripts/package_xcframeworks.sh` - centralized packaging with checksums
+- **Updated**: `Scripts/build.sh` now retries GitHub downloads and falls back to the `codeload.github.com` mirror for FFmpeg sources.
 
 ### 3. Documentation
 - **Updated**: README.md with new installation instructions
@@ -32,6 +34,11 @@ This project has been updated from using **systemLibrary** targets (requiring Ho
 ### 4. Source Code
 - **No changes needed**: Swift code continues to `import CFFmpeg` and `import SwiftFFmpeg` as before
 - CFFmpeg shim headers remain in place for Swift compatibility
+
+## Toolchain Requirements
+
+- Swift tools version **6.0** or newer (Xcode 16.2+ on macOS)
+- Command-line builds must use a Swift 6-compatible toolchain when invoking SwiftPM or the build plugin
 
 ## Migration Path for Users
 
@@ -53,7 +60,7 @@ swift build
 .package(url: "https://github.com/stovak/SwiftFFmpeg.git", from: "1.0.1")
 
 # Build XCFrameworks (one-time, or when updating FFmpeg)
-swift package plugin build-ffmpeg
+SWIFT_FFMPEG_SKIP_BINARIES=1 swift package plugin build-ffmpeg
 
 # Build
 swift build
@@ -78,7 +85,7 @@ Users must:
 ## Next Steps
 
 ### For Development
-1. Build XCFrameworks: `swift package plugin build-ffmpeg`
+1. Build XCFrameworks: `SWIFT_FFMPEG_SKIP_BINARIES=1 swift package plugin build-ffmpeg`
 2. Develop normally: `swift build`, `swift test`
 
 ### For Distribution (Optional)
@@ -89,8 +96,8 @@ Users must:
 
 ## Testing Checklist
 
-- [ ] Run `swift package plugin build-ffmpeg` on arm64 Mac
-- [ ] Run `swift package plugin build-ffmpeg` on x86_64 Mac (if available)
+- [ ] Run `SWIFT_FFMPEG_SKIP_BINARIES=1 swift package plugin build-ffmpeg` on arm64 Mac
+- [ ] Run `SWIFT_FFMPEG_SKIP_BINARIES=1 swift package plugin build-ffmpeg` on x86_64 Mac (if available)
 - [ ] Verify `swift build` succeeds after XCFrameworks are built
 - [ ] Verify `swift test` passes
 - [ ] Test Examples target builds and runs

--- a/MIGRATION_SUMMARY.md
+++ b/MIGRATION_SUMMARY.md
@@ -24,7 +24,7 @@ This project has been updated from using **systemLibrary** targets (requiring Ho
 ### 2. Build Scripts
 - **Modified**: `Scripts/build_framework.sh` - removed individual zip creation
 - **Added**: `Scripts/package_xcframeworks.sh` - centralized packaging with checksums
-- **Updated**: `Scripts/build.sh` now retries GitHub downloads and falls back to the `codeload.github.com` mirror for FFmpeg sources.
+- **Updated**: `Scripts/build.sh` now supports using a pre-cloned FFmpeg source directory (via `FFMPEG_SOURCE_DIR`), retries GitHub downloads with `GITHUB_TOKEN` authentication when available, and falls back to both `codeload.github.com` and API tarball mirrors for FFmpeg sources.
 
 ### 3. Documentation
 - **Updated**: README.md with new installation instructions

--- a/Package.swift
+++ b/Package.swift
@@ -1,7 +1,64 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
+import Foundation
 import PackageDescription
+
+let shouldIncludeBinaryTargets = ProcessInfo.processInfo.environment["SWIFT_FFMPEG_SKIP_BINARIES"] != "1"
+
+let binaryTargetNames = [
+  "libavcodec",
+  "libavdevice",
+  "libavfilter",
+  "libavformat",
+  "libavutil",
+  "libpostproc",
+  "libswresample",
+  "libswscale"
+]
+
+var targets: [Target] = [
+  .plugin(
+    name: "BuildFFmpegPlugin",
+    capability: .command(
+      intent: .custom(
+        verb: "build-ffmpeg",
+        description: "Clone FFmpeg from git and build XCFrameworks"
+      )
+    )
+  )
+]
+
+if shouldIncludeBinaryTargets {
+  targets += binaryTargetNames.map { name in
+    .binaryTarget(
+      name: name,
+      path: "xcframework/\(name).xcframework"
+    )
+  }
+}
+
+let cFFmpegDependencies: [Target.Dependency] = shouldIncludeBinaryTargets ? binaryTargetNames.map { .target(name: $0) } : []
+
+targets += [
+  .target(
+    name: "CFFmpeg",
+    dependencies: cFFmpegDependencies,
+    publicHeadersPath: "."
+  ),
+  .target(
+    name: "SwiftFFmpeg",
+    dependencies: ["CFFmpeg"]
+  ),
+  .executableTarget(
+    name: "Examples",
+    dependencies: ["SwiftFFmpeg"]
+  ),
+  .testTarget(
+    name: "Tests",
+    dependencies: ["SwiftFFmpeg"]
+  )
+]
 
 let package = Package(
   name: "SwiftFFmpeg",
@@ -12,74 +69,5 @@ let package = Package(
       targets: ["SwiftFFmpeg"]
     )
   ],
-  targets: [
-    .plugin(
-      name: "BuildFFmpegPlugin",
-      capability: .command(
-        intent: .custom(
-          verb: "build-ffmpeg",
-          description: "Clone FFmpeg from git and build XCFrameworks"
-        )
-      )
-    ),
-    // FFmpeg XCFramework binary targets
-    .binaryTarget(
-      name: "libavcodec",
-      path: "xcframework/libavcodec.xcframework"
-    ),
-    .binaryTarget(
-      name: "libavdevice",
-      path: "xcframework/libavdevice.xcframework"
-    ),
-    .binaryTarget(
-      name: "libavfilter",
-      path: "xcframework/libavfilter.xcframework"
-    ),
-    .binaryTarget(
-      name: "libavformat",
-      path: "xcframework/libavformat.xcframework"
-    ),
-    .binaryTarget(
-      name: "libavutil",
-      path: "xcframework/libavutil.xcframework"
-    ),
-    .binaryTarget(
-      name: "libpostproc",
-      path: "xcframework/libpostproc.xcframework"
-    ),
-    .binaryTarget(
-      name: "libswresample",
-      path: "xcframework/libswresample.xcframework"
-    ),
-    .binaryTarget(
-      name: "libswscale",
-      path: "xcframework/libswscale.xcframework"
-    ),
-    .target(
-      name: "CFFmpeg",
-      dependencies: [
-        "libavcodec",
-        "libavdevice",
-        "libavfilter",
-        "libavformat",
-        "libavutil",
-        "libpostproc",
-        "libswresample",
-        "libswscale"
-      ],
-      publicHeadersPath: "."
-    ),
-    .target(
-      name: "SwiftFFmpeg",
-      dependencies: ["CFFmpeg"]
-    ),
-    .executableTarget(
-      name: "Examples",
-      dependencies: ["SwiftFFmpeg"]
-    ),
-    .testTarget(
-      name: "Tests",
-      dependencies: ["SwiftFFmpeg"]
-    ),
-  ]
+  targets: targets
 )

--- a/Plugins/BuildFFmpegPlugin/plugin.swift
+++ b/Plugins/BuildFFmpegPlugin/plugin.swift
@@ -65,7 +65,7 @@ struct BuildFFmpegPlugin: CommandPlugin {
         SCRIPTS_DIR="\(scriptsDir.string)"
         PACKAGE_DIR="\(packageDir.string)"
 
-        echo "Building FFmpeg frameworks from the official GitHub archive..."
+        echo "Building FFmpeg frameworks from GitHub sources..."
         echo "Architectures: \(archList.isEmpty ? "default" : archList)"
         echo ""
 

--- a/Plugins/BuildFFmpegPlugin/plugin.swift
+++ b/Plugins/BuildFFmpegPlugin/plugin.swift
@@ -1,5 +1,5 @@
 import PackagePlugin
-import Foundation
+@preconcurrency import Foundation
 
 @main
 struct BuildFFmpegPlugin: CommandPlugin {
@@ -19,6 +19,25 @@ struct BuildFFmpegPlugin: CommandPlugin {
             "libswscale"
         ]
 
+        var requestedArchs: [String] = []
+        var forceRebuild = false
+        var iterator = arguments.makeIterator()
+        while let argument = iterator.next() {
+            switch argument {
+            case "--force":
+                forceRebuild = true
+            case "--arch":
+                guard let value = iterator.next() else { throw PluginError.missingArchitectureValue }
+                requestedArchs.append(value)
+            default:
+                throw PluginError.unknownArgument(argument)
+            }
+        }
+
+        if requestedArchs.isEmpty {
+            requestedArchs.append(try Self.detectHostArchitecture())
+        }
+
         // Check if .xcframework directories already exist
         var allExist = true
         for framework in frameworkNames {
@@ -29,55 +48,54 @@ struct BuildFFmpegPlugin: CommandPlugin {
             }
         }
 
-        // If all frameworks exist and --force is not specified
-        let forceRebuild = arguments.contains("--force")
         if allExist && !forceRebuild {
             print("All frameworks already exist. Use --force to rebuild.")
             return
         }
 
-        // Create a script to build frameworks from FFmpeg source
         let scriptPath = context.pluginWorkDirectory.appending("build_frameworks.sh")
+
+        let archList = requestedArchs.joined(separator: " ")
 
         let scriptContent = """
         #!/bin/bash
-        set -e
+        set -euo pipefail
 
         XCFRAMEWORK_DIR="\(xcframeworkDir.string)"
         SCRIPTS_DIR="\(scriptsDir.string)"
         PACKAGE_DIR="\(packageDir.string)"
 
-        echo "Building FFmpeg frameworks from source..."
-        echo "This will clone FFmpeg 7.1 and compile for your architecture."
+        echo "Building FFmpeg frameworks from the official GitHub archive..."
+        echo "Architectures: \(archList.isEmpty ? "default" : archList)"
         echo ""
 
-        # Check if build script exists
         if [ ! -f "$SCRIPTS_DIR/build.sh" ]; then
             echo "Error: Build script not found at $SCRIPTS_DIR/build.sh"
             exit 1
         fi
 
-        # Run the build script
-        cd "$PACKAGE_DIR"
-        bash "$SCRIPTS_DIR/build.sh"
+        ARCHS="\(archList)"
 
-        # Create xcframework directory if it doesn't exist
+        cd "$PACKAGE_DIR"
+        if [ -n "$ARCHS" ]; then
+            ARCHS="$ARCHS" bash "$SCRIPTS_DIR/build.sh"
+        else
+            bash "$SCRIPTS_DIR/build.sh"
+        fi
+
         mkdir -p "$XCFRAMEWORK_DIR"
 
-        # Copy built frameworks to xcframework directory
-        PREFIX="$PACKAGE_DIR/output"
+        PREFIX="${FFMPEG_OUTPUT_DIR:-$PACKAGE_DIR/output}"
 
         if [ -d "$PREFIX/xcframework" ]; then
-            echo ""
             echo "Copying frameworks to $XCFRAMEWORK_DIR..."
-            cp -R "$PREFIX/xcframework/"* "$XCFRAMEWORK_DIR/" || true
+            rsync -a "$PREFIX/xcframework/" "$XCFRAMEWORK_DIR/"
             echo "Done!"
         else
             echo "Error: No frameworks found in $PREFIX/xcframework"
             exit 1
         fi
 
-        echo ""
         echo "All frameworks are ready in $XCFRAMEWORK_DIR"
         """
 
@@ -95,6 +113,12 @@ struct BuildFFmpegPlugin: CommandPlugin {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/bash")
         process.arguments = [scriptPath.string]
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["FFMPEG_CACHE_DIR"] = context.pluginWorkDirectory.appending("cache").string
+        environment["FFMPEG_OUTPUT_DIR"] = context.pluginWorkDirectory.appending("output").string
+        environment["FFMPEG_BUILD_ROOT_BASE"] = context.pluginWorkDirectory.appending("build").string
+        process.environment = environment
 
         let pipe = Pipe()
         process.standardOutput = pipe
@@ -114,8 +138,47 @@ struct BuildFFmpegPlugin: CommandPlugin {
 
         print("XCFrameworks setup complete!")
     }
+
+    private static func detectHostArchitecture() throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/uname")
+        process.arguments = ["-m"]
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            throw PluginError.buildFailed
+        }
+
+        guard let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !output.isEmpty else {
+            throw PluginError.buildFailed
+        }
+
+        return output
+    }
 }
 
 enum PluginError: Error {
     case buildFailed
+    case unknownArgument(String)
+    case missingArchitectureValue
+}
+
+extension PluginError: LocalizedError {
+    var errorDescription: String? {
+        switch self {
+        case .buildFailed:
+            return "FFmpeg build failed. Check the script output for details."
+        case .unknownArgument(let argument):
+            return "Unknown argument: \(argument)"
+        case .missingArchitectureValue:
+            return "Missing value for --arch option"
+        }
+    }
 }

--- a/Plugins/BuildFFmpegPlugin/plugin.swift
+++ b/Plugins/BuildFFmpegPlugin/plugin.swift
@@ -115,9 +115,17 @@ struct BuildFFmpegPlugin: CommandPlugin {
         process.arguments = [scriptPath.string]
 
         var environment = ProcessInfo.processInfo.environment
-        environment["FFMPEG_CACHE_DIR"] = context.pluginWorkDirectory.appending("cache").string
-        environment["FFMPEG_OUTPUT_DIR"] = context.pluginWorkDirectory.appending("output").string
-        environment["FFMPEG_BUILD_ROOT_BASE"] = context.pluginWorkDirectory.appending("build").string
+        let cacheDir = context.pluginWorkDirectory.appending("cache")
+        let outputDir = context.pluginWorkDirectory.appending("output")
+        let buildRoot = context.pluginWorkDirectory.appending("build")
+        let moduleCacheDir = context.pluginWorkDirectory.appending("clang-module-cache")
+        let tempDir = context.pluginWorkDirectory.appending("tmp")
+
+        environment["FFMPEG_CACHE_DIR"] = cacheDir.string
+        environment["FFMPEG_OUTPUT_DIR"] = outputDir.string
+        environment["FFMPEG_BUILD_ROOT_BASE"] = buildRoot.string
+        environment["FFMPEG_MODULE_CACHE_DIR"] = moduleCacheDir.string
+        environment["FFMPEG_TMP_DIR"] = tempDir.string
         process.environment = environment
 
         let pipe = Pipe()

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -8,6 +8,7 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 FFMPEG_VERSION=${FFMPEG_VERSION:-8.0}
 FFMPEG_ARCHIVE=${FFMPEG_ARCHIVE:-"FFmpeg-n$FFMPEG_VERSION.tar.gz"}
 FFMPEG_SOURCE_URL=${FFMPEG_SOURCE_URL:-"https://github.com/FFmpeg/FFmpeg/archive/refs/tags/n$FFMPEG_VERSION.tar.gz"}
+SOURCE_DIR_OVERRIDE="${FFMPEG_SOURCE_DIR:-}"
 FFMPEG_LIBS="libavcodec libavdevice libavfilter libavformat libavutil libpostproc libswresample libswscale"
 
 HOST_ARCH=$(uname -m)
@@ -34,7 +35,13 @@ download_ffmpeg_source() {
   temp_file="${destination}.partial"
   rm -f "$temp_file"
 
-  if curl -fSL --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors "$url" -o "$temp_file"; then
+  local -a curl_args
+  curl_args=(-fSL --retry 5 --retry-delay 2 --retry-connrefused --retry-all-errors)
+  if [ -n "${GITHUB_TOKEN:-}" ]; then
+    curl_args+=(-H "Authorization: Bearer $GITHUB_TOKEN" -H "X-GitHub-Api-Version: 2022-11-28")
+  fi
+
+  if curl "${curl_args[@]}" "$url" -o "$temp_file"; then
     mv "$temp_file" "$destination"
     return 0
   fi
@@ -44,30 +51,44 @@ download_ffmpeg_source() {
   return 1
 }
 
-if [ ! -f "$SOURCE_ARCHIVE_PATH" ]; then
-  echo "Downloading FFmpeg $FFMPEG_VERSION source"
-
-  FALLBACK_URL="https://codeload.github.com/FFmpeg/FFmpeg/tar.gz/refs/tags/n$FFMPEG_VERSION"
-  CANDIDATE_URLS=("$FFMPEG_SOURCE_URL")
-
-  if [[ "$FALLBACK_URL" != "$FFMPEG_SOURCE_URL" ]]; then
-    CANDIDATE_URLS+=("$FALLBACK_URL")
-  fi
-
-  DOWNLOAD_SUCCEEDED=false
-  for URL in "${CANDIDATE_URLS[@]}"; do
-    if download_ffmpeg_source "$URL" "$SOURCE_ARCHIVE_PATH"; then
-      DOWNLOAD_SUCCEEDED=true
-      break
-    fi
-  done
-
-  if [ "$DOWNLOAD_SUCCEEDED" != true ]; then
-    echo "Unable to download FFmpeg sources. If you are running in a restricted network environment, set FFMPEG_SOURCE_URL to a reachable mirror." >&2
+if [ -n "$SOURCE_DIR_OVERRIDE" ]; then
+  if [ ! -d "$SOURCE_DIR_OVERRIDE" ]; then
+    echo "FFMPEG_SOURCE_DIR is set to '$SOURCE_DIR_OVERRIDE', but that directory does not exist" >&2
     exit 1
   fi
+
+  echo "Using local FFmpeg sources from $SOURCE_DIR_OVERRIDE"
 else
-  echo "Using cached FFmpeg archive at $SOURCE_ARCHIVE_PATH"
+  if [ ! -f "$SOURCE_ARCHIVE_PATH" ]; then
+    echo "Downloading FFmpeg $FFMPEG_VERSION source"
+
+    FALLBACK_URL="https://codeload.github.com/FFmpeg/FFmpeg/tar.gz/refs/tags/n$FFMPEG_VERSION"
+    API_URL="https://api.github.com/repos/FFmpeg/FFmpeg/tarball/n$FFMPEG_VERSION"
+    CANDIDATE_URLS=("$FFMPEG_SOURCE_URL")
+
+    if [[ "$FALLBACK_URL" != "$FFMPEG_SOURCE_URL" ]]; then
+      CANDIDATE_URLS+=("$FALLBACK_URL")
+    fi
+
+    if [[ "$API_URL" != "$FFMPEG_SOURCE_URL" && "$API_URL" != "$FALLBACK_URL" ]]; then
+      CANDIDATE_URLS+=("$API_URL")
+    fi
+
+    DOWNLOAD_SUCCEEDED=false
+    for URL in "${CANDIDATE_URLS[@]}"; do
+      if download_ffmpeg_source "$URL" "$SOURCE_ARCHIVE_PATH"; then
+        DOWNLOAD_SUCCEEDED=true
+        break
+      fi
+    done
+
+    if [ "$DOWNLOAD_SUCCEEDED" != true ]; then
+      echo "Unable to download FFmpeg sources. If you are running in a restricted network environment, set FFMPEG_SOURCE_URL to a reachable mirror." >&2
+      exit 1
+    fi
+  else
+    echo "Using cached FFmpeg archive at $SOURCE_ARCHIVE_PATH"
+  fi
 fi
 
 OUTPUT_DIR="${FFMPEG_OUTPUT_DIR:-$ROOT_DIR/output}"
@@ -87,7 +108,13 @@ for ARCH in "${REQUESTED_ARCHS[@]}"; do
   echo "Preparing build workspace for $ARCH at $BUILD_ROOT"
   rm -rf "$BUILD_ROOT"
   mkdir -p "$BUILD_ROOT"
-  tar -xf "$SOURCE_ARCHIVE_PATH" -C "$BUILD_ROOT" --strip-components=1
+
+  if [ -n "$SOURCE_DIR_OVERRIDE" ]; then
+    echo "Copying FFmpeg sources from $SOURCE_DIR_OVERRIDE"
+    rsync -a --delete --exclude='.git' "$SOURCE_DIR_OVERRIDE"/ "$BUILD_ROOT"/
+  else
+    tar -xf "$SOURCE_ARCHIVE_PATH" -C "$BUILD_ROOT" --strip-components=1
+  fi
 
   pushd "$BUILD_ROOT" >/dev/null
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -25,6 +25,15 @@ SOURCE_ARCHIVE_PATH="$CACHE_DIR/$FFMPEG_ARCHIVE"
 
 mkdir -p "$CACHE_DIR"
 
+MODULE_CACHE_DIR="${FFMPEG_MODULE_CACHE_DIR:-$CACHE_DIR/clang-module-cache}"
+TMP_DIR_OVERRIDE="${FFMPEG_TMP_DIR:-$CACHE_DIR/tmp}"
+
+mkdir -p "$MODULE_CACHE_DIR" "$TMP_DIR_OVERRIDE"
+
+export MODULE_CACHE_DIR="$MODULE_CACHE_DIR"
+export CLANG_MODULE_CACHE_PATH="$MODULE_CACHE_DIR"
+export TMPDIR="$TMP_DIR_OVERRIDE"
+
 download_ffmpeg_source() {
   local url="$1"
   local destination="$2"

--- a/Scripts/build_framework.sh
+++ b/Scripts/build_framework.sh
@@ -1,102 +1,70 @@
 #!/bin/bash
 
+set -euo pipefail
+
+if [ "$#" -lt 4 ]; then
+  echo "Usage: $0 <install-prefix> <library-name> <version> <arch> [output-root]"
+  exit 1
+fi
+
 PREFIX=$1
 LIB_NAME=$2
 LIB_VERSION=$3
+ARCH_NAME=$4
+OUTPUT_ROOT=${5:-$(dirname "$PREFIX")}
 
-# Detect architecture
-ARCH=$(uname -m)
-if [ "$ARCH" = "arm64" ]; then
-    PLATFORM_ID="macos-arm64"
-    ARCH_NAME="arm64"
-elif [ "$ARCH" = "x86_64" ]; then
-    PLATFORM_ID="macos-x86_64"
-    ARCH_NAME="x86_64"
-else
-    echo "Unsupported architecture: $ARCH"
-    exit 1
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+PLATFORM_ID="macos-$ARCH_NAME"
+
+LIB_FRAMEWORK_ROOT="$OUTPUT_ROOT/$ARCH_NAME/framework/$LIB_NAME.framework"
+LIB_XCFRAMEWORK="$OUTPUT_ROOT/xcframework/$LIB_NAME.xcframework"
+
+echo "Preparing framework for $LIB_NAME ($ARCH_NAME)"
+
+rm -rf "$LIB_FRAMEWORK_ROOT"
+mkdir -p "$LIB_FRAMEWORK_ROOT/Headers"
+
+if [ ! -d "$PREFIX/include/$LIB_NAME" ]; then
+  echo "Error: Header directory $PREFIX/include/$LIB_NAME not found"
+  exit 1
 fi
 
-LIB_FRAMEWORK=$PREFIX/framework/$LIB_NAME.framework
-LIB_XCFRAMEWORK=$PREFIX/xcframework/$LIB_NAME.xcframework
-XCFRAMEWORK_DIR=$(dirname $LIB_XCFRAMEWORK)
+rsync -a "$PREFIX/include/$LIB_NAME/" "$LIB_FRAMEWORK_ROOT/Headers/"
+cp "$PREFIX/lib/$LIB_NAME.a" "$LIB_FRAMEWORK_ROOT/$LIB_NAME"
 
-# build framework
-rm -rf $LIB_FRAMEWORK
-
-mkdir -p $LIB_FRAMEWORK/Headers
-cp -R $PREFIX/include/$LIB_NAME/ $LIB_FRAMEWORK/Headers
-
-cp $PREFIX/lib/$LIB_NAME.a $LIB_FRAMEWORK/$LIB_NAME
-
-cat > $LIB_FRAMEWORK/Info.plist << EOF
+cat > "$LIB_FRAMEWORK_ROOT/Info.plist" << EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>CFBundleDevelopmentRegion</key>
-	<string>en</string>
-	<key>CFBundleExecutable</key>
-	<string>$LIB_NAME</string>
-	<key>CFBundleIdentifier</key>
-	<string>org.ffmpeg.$LIB_NAME</string>
-	<key>CFBundleInfoDictionaryVersion</key>
-	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>$LIB_NAME</string>
-	<key>CFBundlePackageType</key>
-	<string>FMWK</string>
-	<key>CFBundleShortVersionString</key>
-	<string>$LIB_VERSION</string>
-	<key>CFBundleVersion</key>
-	<string>$LIB_VERSION</string>
-	<key>CFBundleSignature</key>
-	<string>????</string>
-	<key>NSPrincipalClass</key>
-	<string></string>
+        <key>CFBundleDevelopmentRegion</key>
+        <string>en</string>
+        <key>CFBundleExecutable</key>
+        <string>$LIB_NAME</string>
+        <key>CFBundleIdentifier</key>
+        <string>org.ffmpeg.$LIB_NAME</string>
+        <key>CFBundleInfoDictionaryVersion</key>
+        <string>6.0</string>
+        <key>CFBundleName</key>
+        <string>$LIB_NAME</string>
+        <key>CFBundlePackageType</key>
+        <string>FMWK</string>
+        <key>CFBundleShortVersionString</key>
+        <string>$LIB_VERSION</string>
+        <key>CFBundleVersion</key>
+        <string>$LIB_VERSION</string>
+        <key>CFBundleSignature</key>
+        <string>????</string>
+        <key>NSPrincipalClass</key>
+        <string></string>
 </dict>
 </plist>
 EOF
 
-# build xcframework
-rm -rf $LIB_XCFRAMEWORK
+mkdir -p "$LIB_XCFRAMEWORK/$PLATFORM_ID"
+rsync -a "$LIB_FRAMEWORK_ROOT/" "$LIB_XCFRAMEWORK/$PLATFORM_ID/$LIB_NAME.framework/"
 
-# xcodebuild \
-#   -create-xcframework \
-#   -framework $LIB_FRAMEWORK \
-#   -output $LIB_XCFRAMEWORK
-#
-# error: unable to find any specific architecture information in the binary at xxx
+"$SCRIPT_DIR/update_xcframework_info.sh" "$LIB_XCFRAMEWORK" "$LIB_NAME"
 
-mkdir -p $LIB_XCFRAMEWORK/$PLATFORM_ID
-cp -R $LIB_FRAMEWORK $LIB_XCFRAMEWORK/$PLATFORM_ID
-
-cat > $LIB_XCFRAMEWORK/Info.plist << EOF
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>AvailableLibraries</key>
-	<array>
-		<dict>
-			<key>LibraryIdentifier</key>
-			<string>$PLATFORM_ID</string>
-			<key>LibraryPath</key>
-			<string>$LIB_NAME.framework</string>
-			<key>SupportedArchitectures</key>
-			<array>
-				<string>$ARCH_NAME</string>
-			</array>
-			<key>SupportedPlatform</key>
-			<string>macos</string>
-		</dict>
-	</array>
-	<key>CFBundlePackageType</key>
-	<string>XFWK</string>
-	<key>XCFrameworkFormatVersion</key>
-	<string>1.0</string>
-</dict>
-</plist>
-EOF
-
-echo "Built $LIB_NAME.xcframework successfully"
+echo "Built $LIB_NAME.xcframework slice for $ARCH_NAME"

--- a/Scripts/update_xcframework_info.sh
+++ b/Scripts/update_xcframework_info.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [ "$#" -lt 2 ]; then
+  echo "Usage: $0 <xcframework-dir> <library-name>"
+  exit 1
+fi
+
+XCFRAMEWORK_DIR=$1
+LIB_NAME=$2
+
+if [ ! -d "$XCFRAMEWORK_DIR" ]; then
+  echo "Error: $XCFRAMEWORK_DIR is not a directory"
+  exit 1
+fi
+
+AVAILABLE_LIBRARIES=""
+while IFS= read -r variant_dir; do
+  base=$(basename "$variant_dir")
+  arch_segment=${base#macos-}
+  if [ "$arch_segment" = "$base" ]; then
+    continue
+  fi
+
+  ARCH_ELEMENTS=""
+  for arch in $arch_segment; do
+    ARCH_ELEMENTS+="                        <string>$arch</string>"$'\n'
+  done
+
+  AVAILABLE_LIBRARIES+="                <dict>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>LibraryIdentifier</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>$base</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>LibraryPath</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>$LIB_NAME.framework</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>SupportedArchitectures</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <array>"$'\n'
+  AVAILABLE_LIBRARIES+="$ARCH_ELEMENTS"
+  AVAILABLE_LIBRARIES+="                        </array>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <key>SupportedPlatform</key>"$'\n'
+  AVAILABLE_LIBRARIES+="                        <string>macos</string>"$'\n'
+  AVAILABLE_LIBRARIES+="                </dict>"$'\n'
+
+done < <(find "$XCFRAMEWORK_DIR" -mindepth 1 -maxdepth 1 -type d -not -name "__MACOSX" | sort)
+
+cat > "$XCFRAMEWORK_DIR/Info.plist" <<EOF_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+        <key>AvailableLibraries</key>
+        <array>
+$(printf "%b" "$AVAILABLE_LIBRARIES")        </array>
+        <key>CFBundlePackageType</key>
+        <string>XFWK</string>
+        <key>XCFrameworkFormatVersion</key>
+        <string>1.0</string>
+</dict>
+</plist>
+EOF_PLIST

--- a/XCFRAMEWORK_SETUP.md
+++ b/XCFRAMEWORK_SETUP.md
@@ -47,7 +47,8 @@ SwiftFFmpeg Package
    ```bash
    SWIFT_FFMPEG_SKIP_BINARIES=1 swift package plugin build-ffmpeg
    ```
-   The environment variable allows the plugin to run before any XCFrameworks exist by skipping SwiftPM's binary target validation. The plugin downloads the official FFmpeg 8.0 release archive from the GitHub `FFmpeg/FFmpeg` repository—automatically retrying and falling back to the `codeload.github.com` mirror if necessary—compiles the required libraries for your host architecture, and copies the resulting slices to `xcframework/`. Set `FFMPEG_SOURCE_URL` when you must point the build at an internal mirror.
+   The environment variable allows the plugin to run before any XCFrameworks exist by skipping SwiftPM's binary target validation. The plugin uses a pre-cloned FFmpeg source directory when `FFMPEG_SOURCE_DIR` is set (GitHub Actions does this automatically) or downloads the official FFmpeg 8.0 release archive from the GitHub `FFmpeg/FFmpeg` repository—automatically retrying, authenticating with `GITHUB_TOKEN` when available, and falling back to the `codeload.github.com` and API tarball mirrors if necessary—compiles the required libraries for your host architecture, and copies the resulting slices to `xcframework/`. Set `FFMPEG_SOURCE_URL` when you must point the build at an internal mirror.
+   > **Tip:** In automation you can clone `FFmpeg/FFmpeg` with `actions/checkout` (or any Git client) and export `FFMPEG_SOURCE_DIR` to reuse that copy instead of performing another network download during the build step.
 3. The frameworks will be placed in `xcframework/` directory
 4. Build your project:
    ```bash


### PR DESCRIPTION
## Summary
- add retry and fallback logic when fetching the FFmpeg source archive in build.sh
- document the resilient download behaviour and mirror override in the README and XCFRAMEWORK_SETUP guide
- note the new download fallback in the migration summary for future reference

## Testing
- SWIFT_FFMPEG_SKIP_BINARIES=1 swift package describe

------
https://chatgpt.com/codex/tasks/task_e_68e43bd0fe188321a39cb313530c8a19